### PR TITLE
Fixed #2 Status LED can't be turned off permanently.

### DIFF
--- a/athom_ps01.yaml
+++ b/athom_ps01.yaml
@@ -111,13 +111,12 @@ binary_sensor:
 #    filters:
 #      - delayed_on: 50ms
     device_class: occupancy
-    on_press:
-      then:
-        - light.turn_on: led
-    on_release:
-      then:
-        - light.turn_off: led
-
+#    on_press:
+#      then:
+#        - light.turn_on: led
+#    on_release:
+#      then:
+#        - light.turn_off: led
 
   - platform: template
     name: "Occupancy"

--- a/athom_ps01.yaml
+++ b/athom_ps01.yaml
@@ -24,6 +24,7 @@ logger:
 api:
 
 ota:
+  platform: esphome
 
 mdns:
   disabled: false


### PR DESCRIPTION
Fixes: https://github.com/blakadder/esphome-configs/issues/2

It's really annoying that this light is on and really bright especially at night time. I get a lot of complaints. I feel like if someone wants this on, write an automation for it (or we introduce an option toggle defaulted to off).